### PR TITLE
Use MIT/X11 license

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,21 @@
+Copyright © 2010-2015 RedJack LLC.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/COPYING.dkjson
+++ b/COPYING.dkjson
@@ -1,0 +1,24 @@
+This software contains an embedded copy of dkjson, which is released
+under the following license:
+
+*Copyright (C) 2010, 2011 David Heiko Kolf*
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 #----------------------------------------------------------------------
-# Copyright © 2011, RedJack, LLC.
+# Copyright © 2011-2015, RedJack, LLC.
 # All rights reserved.
 #
-# Please see the LICENSE.txt file in this distribution for license
-# details.
+# Please see the COPYING file in this distribution for license details.
 #----------------------------------------------------------------------
 
 all: test-prereqs build

--- a/rockspecs/lua-avro-0.1.rockspec
+++ b/rockspecs/lua-avro-0.1.rockspec
@@ -9,7 +9,7 @@ source = {
 description = {
    summary = "Lua bindings for Avro C library",
    homepage = "http://git.redjack.com/fathom/lua-avro",
-   license = "Proprietary"
+   license = "MIT/X11"
 }
 
 dependencies = {

--- a/rockspecs/lua-avro-0.2.1.rockspec
+++ b/rockspecs/lua-avro-0.2.1.rockspec
@@ -9,7 +9,7 @@ source = {
 description = {
    summary = "Lua bindings for Avro C library",
    homepage = "http://git.redjack.com/fathom/lua-avro",
-   license = "Proprietary"
+   license = "MIT/X11"
 }
 
 dependencies = {

--- a/rockspecs/lua-avro-0.2.2.rockspec
+++ b/rockspecs/lua-avro-0.2.2.rockspec
@@ -9,7 +9,7 @@ source = {
 description = {
    summary = "Lua bindings for Avro C library",
    homepage = "http://git.redjack.com/fathom/lua-avro",
-   license = "Proprietary"
+   license = "MIT/X11"
 }
 
 dependencies = {

--- a/rockspecs/lua-avro-0.2.rockspec
+++ b/rockspecs/lua-avro-0.2.rockspec
@@ -9,7 +9,7 @@ source = {
 description = {
    summary = "Lua bindings for Avro C library",
    homepage = "http://git.redjack.com/fathom/lua-avro",
-   license = "Proprietary"
+   license = "MIT/X11"
 }
 
 dependencies = {

--- a/rockspecs/lua-avro-0.3.rockspec
+++ b/rockspecs/lua-avro-0.3.rockspec
@@ -9,7 +9,7 @@ source = {
 description = {
    summary = "Lua bindings for Avro C library",
    homepage = "http://git.redjack.com/fathom/lua-avro",
-   license = "Proprietary"
+   license = "MIT/X11"
 }
 
 dependencies = {

--- a/rockspecs/lua-avro-0.4.1.rockspec
+++ b/rockspecs/lua-avro-0.4.1.rockspec
@@ -9,7 +9,7 @@ source = {
 description = {
    summary = "Lua bindings for Avro C library",
    homepage = "http://git.redjack.com/fathom/lua-avro",
-   license = "Proprietary"
+   license = "MIT/X11"
 }
 
 dependencies = {

--- a/rockspecs/lua-avro-0.4.2.rockspec
+++ b/rockspecs/lua-avro-0.4.2.rockspec
@@ -9,7 +9,7 @@ source = {
 description = {
    summary = "Lua bindings for Avro C library",
    homepage = "http://git.redjack.com/fathom/lua-avro",
-   license = "Proprietary"
+   license = "MIT/X11"
 }
 
 dependencies = {

--- a/rockspecs/lua-avro-0.4.3.rockspec
+++ b/rockspecs/lua-avro-0.4.3.rockspec
@@ -9,7 +9,7 @@ source = {
 description = {
    summary = "Lua bindings for Avro C library",
    homepage = "http://git.redjack.com/fathom/lua-avro",
-   license = "Proprietary"
+   license = "MIT/X11"
 }
 
 dependencies = {

--- a/rockspecs/lua-avro-0.4.rockspec
+++ b/rockspecs/lua-avro-0.4.rockspec
@@ -9,7 +9,7 @@ source = {
 description = {
    summary = "Lua bindings for Avro C library",
    homepage = "http://git.redjack.com/fathom/lua-avro",
-   license = "Proprietary"
+   license = "MIT/X11"
 }
 
 dependencies = {

--- a/rockspecs/lua-avro-0.5.rockspec
+++ b/rockspecs/lua-avro-0.5.rockspec
@@ -9,7 +9,7 @@ source = {
 description = {
    summary = "Lua bindings for Avro C library",
    homepage = "http://git.redjack.com/fathom/lua-avro",
-   license = "Proprietary"
+   license = "MIT/X11"
 }
 
 dependencies = {

--- a/rockspecs/lua-avro-0.6.rockspec
+++ b/rockspecs/lua-avro-0.6.rockspec
@@ -9,7 +9,7 @@ source = {
 description = {
    summary = "Lua bindings for Avro C library",
    homepage = "http://git.redjack.com/fathom/lua-avro",
-   license = "Proprietary"
+   license = "MIT/X11"
 }
 
 dependencies = {

--- a/rockspecs/lua-avro-0.7.rockspec
+++ b/rockspecs/lua-avro-0.7.rockspec
@@ -9,7 +9,7 @@ source = {
 description = {
    summary = "Lua bindings for Avro C library",
    homepage = "http://git.redjack.com/fathom/lua-avro",
-   license = "Proprietary"
+   license = "MIT/X11"
 }
 
 dependencies = {

--- a/rockspecs/lua-avro-0.8.rockspec
+++ b/rockspecs/lua-avro-0.8.rockspec
@@ -9,7 +9,7 @@ source = {
 description = {
    summary = "Lua bindings for Avro C library",
    homepage = "http://git.redjack.com/fathom/lua-avro",
-   license = "Proprietary"
+   license = "MIT/X11"
 }
 
 dependencies = {

--- a/rockspecs/lua-avro-0.9.rockspec
+++ b/rockspecs/lua-avro-0.9.rockspec
@@ -9,7 +9,7 @@ source = {
 description = {
    summary = "Lua bindings for Avro C library",
    homepage = "http://git.redjack.com/fathom/lua-avro",
-   license = "Proprietary"
+   license = "MIT/X11"
 }
 
 dependencies = {

--- a/rockspecs/lua-avro-scm-0.rockspec
+++ b/rockspecs/lua-avro-scm-0.rockspec
@@ -9,7 +9,7 @@ source = {
 description = {
    summary = "Lua bindings for Avro C library",
    homepage = "http://git.redjack.com/fathom/lua-avro",
-   license = "Proprietary"
+   license = "MIT/X11"
 }
 
 dependencies = {

--- a/src/avro.lua
+++ b/src/avro.lua
@@ -1,10 +1,9 @@
 -- -*- coding: utf-8 -*-
 ------------------------------------------------------------------------
--- Copyright © 2011, RedJack, LLC.
+-- Copyright © 2011-2015, RedJack, LLC.
 -- All rights reserved.
 --
--- Please see the LICENSE.txt file in this distribution for license
--- details.
+-- Please see the COPYING file in this distribution for license details.
 ------------------------------------------------------------------------
 
 local AC = require "avro.c"

--- a/src/avro/c.lua
+++ b/src/avro/c.lua
@@ -1,10 +1,9 @@
 -- -*- coding: utf-8 -*-
 ------------------------------------------------------------------------
--- Copyright © 2011, RedJack, LLC.
+-- Copyright © 2011-2015, RedJack, LLC.
 -- All rights reserved.
 --
--- Please see the LICENSE.txt file in this distribution for license
--- details.
+-- Please see the COPYING file in this distribution for license details.
 ------------------------------------------------------------------------
 
 -- Loads either avro.legacy.avro or avro.ffi.avro, depending on whether

--- a/src/avro/constants.lua
+++ b/src/avro/constants.lua
@@ -1,10 +1,9 @@
 -- -*- coding: utf-8 -*-
 ------------------------------------------------------------------------
--- Copyright © 2011, RedJack, LLC.
+-- Copyright © 2011-2015, RedJack, LLC.
 -- All rights reserved.
 --
--- Please see the LICENSE.txt file in this distribution for license
--- details.
+-- Please see the COPYING file in this distribution for license details.
 ------------------------------------------------------------------------
 
 module "avro.constants"

--- a/src/avro/ffi/avro.lua
+++ b/src/avro/ffi/avro.lua
@@ -1,10 +1,9 @@
 -- -*- coding: utf-8 -*-
 ------------------------------------------------------------------------
--- Copyright © 2011, RedJack, LLC.
+-- Copyright © 2011-2015, RedJack, LLC.
 -- All rights reserved.
 --
--- Please see the LICENSE.txt file in this distribution for license
--- details.
+-- Please see the COPYING file in this distribution for license details.
 ------------------------------------------------------------------------
 
 -- A LuaJIT FFI implementation of the Avro C bindings.

--- a/src/avro/legacy/avro.c
+++ b/src/avro/legacy/avro.c
@@ -1,10 +1,9 @@
 /* -*- coding: utf-8 -*-
  * ----------------------------------------------------------------------
- * Copyright © 2010, RedJack, LLC.
+ * Copyright © 2010-2015, RedJack, LLC.
  * All rights reserved.
  *
- * Please see the LICENSE.txt file in this distribution for license
- * details.
+ * Please see the COPYING file in this distribution for license details.
  * ----------------------------------------------------------------------
  */
 

--- a/src/avro/schema.lua
+++ b/src/avro/schema.lua
@@ -1,10 +1,9 @@
 -- -*- coding: utf-8 -*-
 ------------------------------------------------------------------------
--- Copyright © 2011, RedJack, LLC.
+-- Copyright © 2011-2015, RedJack, LLC.
 -- All rights reserved.
 --
--- Please see the LICENSE.txt file in this distribution for license
--- details.
+-- Please see the COPYING file in this distribution for license details.
 ------------------------------------------------------------------------
 
 local AC = require "avro.c"

--- a/src/avro/test.lua
+++ b/src/avro/test.lua
@@ -1,10 +1,9 @@
 -- -*- coding: utf-8 -*-
 ------------------------------------------------------------------------
--- Copyright © 2011, RedJack, LLC.
+-- Copyright © 2011-2015, RedJack, LLC.
 -- All rights reserved.
 --
--- Please see the LICENSE.txt file in this distribution for license
--- details.
+-- Please see the COPYING file in this distribution for license details.
 ------------------------------------------------------------------------
 
 require "avro.tests.schema"

--- a/src/avro/tests/raw.lua
+++ b/src/avro/tests/raw.lua
@@ -1,10 +1,9 @@
 -- -*- coding: utf-8 -*-
 ------------------------------------------------------------------------
--- Copyright © 2011, RedJack, LLC.
+-- Copyright © 2011-2015, RedJack, LLC.
 -- All rights reserved.
 --
--- Please see the LICENSE.txt file in this distribution for license
--- details.
+-- Please see the COPYING file in this distribution for license details.
 ------------------------------------------------------------------------
 
 local A = require "avro"

--- a/src/avro/tests/schema.lua
+++ b/src/avro/tests/schema.lua
@@ -1,10 +1,9 @@
 -- -*- coding: utf-8 -*-
 ------------------------------------------------------------------------
--- Copyright © 2011, RedJack, LLC.
+-- Copyright © 2011-2015, RedJack, LLC.
 -- All rights reserved.
 --
--- Please see the LICENSE.txt file in this distribution for license
--- details.
+-- Please see the COPYING file in this distribution for license details.
 ------------------------------------------------------------------------
 
 local A = require "avro"

--- a/src/avro/tests/wrapper.lua
+++ b/src/avro/tests/wrapper.lua
@@ -1,10 +1,9 @@
 -- -*- coding: utf-8 -*-
 ------------------------------------------------------------------------
--- Copyright © 2011, RedJack, LLC.
+-- Copyright © 2011-2015, RedJack, LLC.
 -- All rights reserved.
 --
--- Please see the LICENSE.txt file in this distribution for license
--- details.
+-- Please see the COPYING file in this distribution for license details.
 ------------------------------------------------------------------------
 
 local A = require "avro"

--- a/src/avro/wrapper.lua
+++ b/src/avro/wrapper.lua
@@ -1,10 +1,9 @@
 -- -*- coding: utf-8 -*-
 ------------------------------------------------------------------------
--- Copyright © 2011, RedJack, LLC.
+-- Copyright © 2011-2015, RedJack, LLC.
 -- All rights reserved.
 --
--- Please see the LICENSE.txt file in this distribution for license
--- details.
+-- Please see the COPYING file in this distribution for license details.
 ------------------------------------------------------------------------
 
 local ACC = require "avro.constants"


### PR DESCRIPTION
We weren't clear before on what licensing terms the code was released under.  (The rockspecs even claimed that it was proprietary!)  We're now explicit about releasing the code under the MIT/X11 license, just like the rest of Lua.  I've also included a top-level COPYING file for the dkjson module, which we use an embedded copy of, and which is also release under the MIT/X11 license.